### PR TITLE
added the option to allow for group overviews broken down by series key

### DIFF
--- a/app/frontend/vue/home/analysis-view.vue
+++ b/app/frontend/vue/home/analysis-view.vue
@@ -599,7 +599,7 @@
                 const resultsOfWeek = this.results.filter(res => res?.test_week === week)
                 // collect all y values belonging to the seriesKey in question this week
                 const yValuesOfWeekAndKey = resultsOfWeek.map(res => res.views[view.key][seriesKey])
-                    .filter(yVal => yVal !== null || undefined)
+                    .filter(yVal => yVal != null)
                 // calculate the average by dividing the sum through the number of results for this key this week
                 acc.push({
                   x: this.printDate(week),


### PR DESCRIPTION
This works through calculating a series for each key based on the average of the group for any given week.

If you don't think this can be a useful option then feel free to close this PR.
Our own tests mistakenly set `group: true` in their `test.json` files when per series key views are specified, though this is currently not supported, as I realized now.

So I made this small PR to add support for `group: true` configurations on views containing `series_keys`.