### PR TITLE
added an event listener preventing navigation

### DIFF
--- a/app/views/results/edit.html.erb
+++ b/app/views/results/edit.html.erb
@@ -49,6 +49,13 @@
     const font_size = <%= @student.get_setting("font_size") %>
     window.font_size = font_size
 
+    function preventNavigation(navEvent) {
+        // Cancel the event as stated by the standard.
+        navEvent.preventDefault();
+        // Chrome requires returnValue to be set.
+        navEvent.returnValue = '';
+    }
+
     //Funktionen für Testumgebung bereitstellen
     function saveResults(views, report, data, callback) {
         let url = '<%= student_results_url(@student)%>'
@@ -87,12 +94,16 @@
                         $('#error_message').show()
                     })
             })
+        // Once the results have been saved we assume it is safe to allow navigation again
+        // This is also a measure to make sure that the event listener is removed, even when exit() is not called
+        window.removeEventListener('beforeunload', preventNavigation, true);
     }
     window.saveResults = saveResults
 
     //Testfenster schließen
     function exit() {
         window.location.href = '<%= @redirect %>'
+        window.removeEventListener('beforeunload', preventNavigation, true);
     }
     window.exit = exit
 
@@ -176,6 +187,9 @@
       //window.location.hash = 'no-back-button'
       //window.location.hash = 'Again-No-back-button'
       //window.onhashchange = function() { window.location.hash = 'no-back-button' }
+
+      // interrupt attempts to navigate away
+      window.addEventListener('beforeunload', preventNavigation, true)
       document.title = "<%= @test.level %>"
     <%end%>
 </script>


### PR DESCRIPTION
Auf der Testseite wird nun `window.beforeunload` abgefangen, um das Wegnavigieren zu vermeiden.

In einer Mail kam schonmal raus, dass `window.beforeunload` in einer Masterarbeit zu Levumi irgendwann mal Probleme gemacht haben könnte. Ich weiß natürlich nicht welche, aber ich sehe aktuell nicht direkt eine Alternative, bzw. dieser Ansatz scheint mir der allgemein kompatibelste zu sein.
(Chrome und Firefox habe ich getestet, Safari auf iOS könnte problematisch sein; das müsste man bei Zeiten noch ausprobieren.)

Ich habe es so gestaltet, dass der event listener entfernt wird wenn `saveResults`oder `exit` aufgerufen wird (um die automatische Navigation zurück nicht zu behindern, bzw. die Navigationshürde zu entfernen sobald Ergebnisse gespeichert wurden und der Test im Wesentlichen als abgeschlossen angenommen werden kann).